### PR TITLE
replace hard-coded  download URL

### DIFF
--- a/arch/get-the-keys-and-repos.sh
+++ b/arch/get-the-keys-and-repos.sh
@@ -3,6 +3,7 @@
 ######################################################################################################################
 
 sudo pacman -S wget --noconfirm --needed
+sudo pacman -S jq --noconfirm --needed
 
 echo "Getting the ArcoLinux keys from the ArcoLinux repo"
 

--- a/arch/get-the-keys-and-repos.sh
+++ b/arch/get-the-keys-and-repos.sh
@@ -6,15 +6,15 @@ sudo pacman -S wget --noconfirm --needed
 
 echo "Getting the ArcoLinux keys from the ArcoLinux repo"
 
-sudo wget https://github.com/arcolinux/arcolinux_repo/raw/main/x86_64/arcolinux-keyring-20251209-3-any.pkg.tar.zst -O /tmp/arcolinux-keyring-20251209-3-any.pkg.tar.zst
-sudo pacman -U --noconfirm --needed /tmp/arcolinux-keyring-20251209-3-any.pkg.tar.zst
+sudo wget "$(echo "$response" | jq -r '[.[] | select(.name | contains("arcolinux-keyring")) | .name] | .[0] | sub("arcolinux-keyring-"; "https://github.com/arcolinux/arcolinux_repo/raw/main/x86_64/arcolinux-keyring-")')" -O /tmp/arcolinux-any.pkg.tar.zst
+sudo pacman -U --noconfirm --needed /tmp/arcolinux-any.pkg.tar.zst
 
 ######################################################################################################################
 
 echo "Getting the latest arcolinux mirrors file"
 
-sudo wget https://github.com/arcolinux/arcolinux_repo/raw/main/x86_64/arcolinux-mirrorlist-git-24.03-12-any.pkg.tar.zst -O /tmp/arcolinux-mirrorlist-git-24.03-12-any.pkg.tar.zst
-sudo pacman -U --noconfirm --needed /tmp/arcolinux-mirrorlist-git-24.03-12-any.pkg.tar.zst
+sudo wget "$(echo "$response" | jq -r '[.[] | select(.name | contains("arcolinux-mirrorlist-git-")) | .name] | .[0] | sub("arcolinux-mirrorlist-git-"; "https://github.com/arcolinux/arcolinux_repo/raw/main/x86_64/arcolinux-mirrorlist-git-")')" -O /tmp/arcolinux-mirrorlist-git-any.pkg.tar.zst
+sudo pacman -U --noconfirm --needed /tmp/arcolinux-mirrorlist-git-any.pkg.tar.zst
 echo '
 
 #[arcolinux_repo_testing]


### PR DESCRIPTION
This PR updates the script to prevent potential issues caused by hard-coded download URLs, which can become outdated over time. Instead, it dynamically fetches the latest version from the repository, ensuring reliability and future-proofing the script.


Thanks for this repo, @erikdubois.  Arcolinux is awesome