### PR TITLE
removed Obsolete nvram variable

### DIFF
--- a/AUR/install-qemu.sh
+++ b/AUR/install-qemu.sh
@@ -61,12 +61,6 @@ user=$(whoami)
 sudo gpasswd -a $user libvirt
 sudo gpasswd -a $user kvm
 
-
-echo '
-nvram = [
-    "/usr/share/ovmf/x64/OVMF_CODE.fd:/usr/share/ovmf/x64/OVMF_VARS.fd"
-]' | sudo tee --append /etc/libvirt/qemu.conf
-
 sudo virsh net-define /etc/libvirt/qemu/networks/default.xml
 
 sudo virsh net-autostart default


### PR DESCRIPTION
Obsolete nvram variable is set while firmware metadata files found. Note that the nvram config file variable is going to be ignored. libvirt will automatically handle the firmware images without needing the nvram configuration in qemu.conf


fix: #10 

[Ref](https://listman.redhat.com/archives/libvir-list/2019-May/msg00003.html)