### PR TITLE
Remove picom-git in virtual machine environments

### DIFF
--- a/Personal/999-last-changes.sh
+++ b/Personal/999-last-changes.sh
@@ -153,7 +153,7 @@ fi
 # Remove picom-git if running in a virtual machine
 result=$(systemd-detect-virt)
 if [ $(systemd-detect-virt) != "none" ]; then 
-    pacman -R picom-git 
+    sudo pacman -R picom-git 
 fi
 
 echo

--- a/Personal/999-last-changes.sh
+++ b/Personal/999-last-changes.sh
@@ -150,6 +150,12 @@ if grep -q "ArchBang" /etc/os-release; then
   fi
 fi
 
+# Remove picom-git if running in a virtual machine
+result=$(systemd-detect-virt)
+if [ $(systemd-detect-virt) != "none" ]; then 
+    pacman -R picom-git 
+fi
+
 echo
 tput setaf 6
 echo "##############################################################"


### PR DESCRIPTION
I have noticed that on a few occasions when on a VM , you needed to remove picom-git from the machine after running the nemesis scripts. This adds logic that will remove the package automatically if not running in a visualised environment